### PR TITLE
Add experimental support for modular projects

### DIFF
--- a/.makefile
+++ b/.makefile
@@ -54,7 +54,7 @@ vpath %.o           $(OBJDIR)
 $(TARGET): $(OBJFILES)
 	make --directory=$(OBJDIR)/
 
-.SECO
+.SECONDEXPANSION:
 %.o: %.$(SRCEXT) $(DEPDIR)/%.d | $(DEPDIR)
 	@echo Compiling $@
 	@$(COMPILE) -o $(OBJDIR)/$@ $<

--- a/.makefile
+++ b/.makefile
@@ -22,11 +22,16 @@ DEPDIR           := dep
 INCEXT           :=
 SRCEXT           :=
 
-# Files
+# Modules
 #-----------------------------------------------------------
-SRCFILES         := # Source files
-export OBJFILES  := $(SRCFILES:%.$(SRCEXT)=%.o)
-DEPFILES         := $(SRCFILES:%.$(SRCEXT)=$(DEPDIR)/%.d)
+export SRCFILES  := # Other modules will append to this
+MODULES          := # Modules
+include $(patsubst %,/src/%/module.mk, $(MODULES))
+
+# Build files
+#-----------------------------------------------------------
+export OBJFILES  := $(subst /,.,$(SRCFILES:%.$(SRCEXT)=%.o))
+DEPFILES         := $(patsubst %,$(DEPDIR)/%.d,$(subst /,.,$(basename $(SRCFILES))))
 
 # Target
 #-----------------------------------------------------------
@@ -49,7 +54,7 @@ vpath %.o           $(OBJDIR)
 $(TARGET): $(OBJFILES)
 	make --directory=$(OBJDIR)/
 
-%.o: %.$(SRCEXT)
+.SECO
 %.o: %.$(SRCEXT) $(DEPDIR)/%.d | $(DEPDIR)
 	@echo Compiling $@
 	@$(COMPILE) -o $(OBJDIR)/$@ $<


### PR DESCRIPTION
Allow the user to split source files across multiple directories and reference them using `module.mk` files, local to a given directory.
This way, we avoid [recursion in makefiles](https://accu.org/journals/overload/14/71/miller_2004/).